### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Things you may want to cover:
 
 ## items テーブル
 
-| Column         | Type       | Options                        |
-| -------------- | ---------- | ------------------------------ |
-| user           | references | null: false, foreign_key: true |
-| name           | string     | null: false                    |
-| explanation    | text       | null: false                    |
-| price          | integer    | null: false                    |
-| category_id    | integer    | null: false                    |
-| item_status_id | integer    | null: false                    |
-| send_area_id   | integer    | null: false                    |
-| send_date_id   | integer    | null: false                    |
-| send_fee_id    | integer    | null: false                    |
+| Column                | Type       | Options                        |
+| --------------------- | ---------- | ------------------------------ |
+| user                  | references | null: false, foreign_key: true |
+| name                  | string     | null: false                    |
+| explanation           | text       | null: false                    |
+| price                 | integer    | null: false                    |
+| category_choice_id    | integer    | null: false                    |
+| item_status_choice_id | integer    | null: false                    |
+| send_area_choice_id   | integer    | null: false                    |
+| send_date_choice_id   | integer    | null: false                    |
+| send_fee_choice_id    | integer    | null: false                    |
 
 ### Association
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,8 @@ class ItemsController < ApplicationController
     end
     
     def show
-
+        @items = Item.order("created_at DESC")
+        # binding.pry
     end
 
     def create
@@ -28,7 +29,7 @@ class ItemsController < ApplicationController
     private
 
     def item_params
-        params.require(:item).permit(:image, :name, :explanation, :price, :category_id, :item_status_id, :send_area_id, :send_date_id, :send_fee_id).merge(user_id: current_user.id)
+        params.require(:item).permit(:image, :name, :explanation, :price, :category_choice_id, :item_status_choice_id, :send_area_choice_id, :send_date_choice_id, :send_fee_choice_id).merge(user_id: current_user.id)
     end
 
     def move_to_sign_in

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,16 +1,18 @@
 class ItemsController < ApplicationController
+    before_action :set_item, only: [:show]
     before_action :move_to_sign_in, except: [:index, :show, :search]
 
     def index
         @items = Item.includes(:user).order("created_at DESC")
     end
 
-    def show
-        
-    end
-
+    
     def new
         @item = Item.new
+    end
+    
+    def show
+
     end
 
     def create
@@ -33,5 +35,9 @@ class ItemsController < ApplicationController
         unless user_signed_in?
             redirect_to  new_user_session_path
         end
+    end
+
+    def set_item
+        @item = Item.find(params[:id])
     end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,10 @@ class ItemsController < ApplicationController
         @items = Item.includes(:user).order("created_at DESC")
     end
 
+    def show
+        
+    end
+
     def new
         @item = Item.new
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,7 +13,6 @@ class ItemsController < ApplicationController
     
     def show
         @items = Item.order("created_at DESC")
-        # binding.pry
     end
 
     def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,4 @@
 class Item < ApplicationRecord
-    belongs_to :user
-    has_one_attached :image
-
     extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to_active_hash :category_choice
     belongs_to_active_hash :item_status_choice
@@ -9,12 +6,15 @@ class Item < ApplicationRecord
     belongs_to_active_hash :send_date_choice
     belongs_to_active_hash :send_fee_choice
 
+    belongs_to :user
+    has_one_attached :image
+
     with_options presence: true do
-        validates :name, :explanation, :price, :category_id, :item_status_id, :send_area_id, :send_date_id, :send_fee_id ,:image
+        validates :name, :explanation, :price, :category_choice_id, :item_status_choice_id, :send_area_choice_id, :send_date_choice_id, :send_fee_choice_id ,:image
     end
     
     with_options numericality: { other_than: 1, message: " Other than '---' select"} do
-        validates :category_id, :item_status_id, :send_area_id, :send_date_id, :send_fee_id
+        validates :category_choice_id, :item_status_choice_id, :send_area_choice_id, :send_date_choice_id, :send_fee_choice_id
     end
 
     validates :price, 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,8 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% @items.each do |item| %>    
+      <%= link_to  "/items/#{ item.id }" do %>
       <li class='list'>
-
-        <%= link_to "#" do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %> 
 
@@ -157,8 +156,8 @@
               </div>
             </div>
           </div>
-        <% end %> 
       </li>
+      <% end %>  
     <% end %> 
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,8 +128,8 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% @items.each do |item| %>    
-      <%= link_to  "/items/#{ item.id }" do %>
       <li class='list'>
+        <%= link_to  "/items/#{ item.id }" do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %> 
 
@@ -156,8 +156,8 @@
               </div>
             </div>
           </div>
+        <% end %>  
       </li>
-      <% end %>  
     <% end %> 
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,45 +125,67 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-    <% @items.each do |item| %>    
-      <li class='list'>
-        <%= link_to  "/items/#{ item.id }" do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %> 
+      <% @items.each do |item| %>    
+        <li class='list'>
+          <%= link_to item_path(item.id) do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %> 
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <%# 購入テーブル(purchases)内に該当商品(purchases)のidが見つかれば"Sold"を表示する(購入機能実装後着手) %>
-            <%# <% if @purchase("Purchase.find(params[:item_id]") = item.id %> 
-              <%# <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div> %>
-            <%# <% end %> 
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <%# 購入テーブル(purchases)内に該当商品(purchases)のidが見つかれば"Sold"を表示する(購入機能実装後着手) %>
+              <%# <% if @purchase("Purchase.find(params[:item_id]") = item.id %> 
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+              <%# <% end %> 
 
-            <%# //商品が売れていればsold outを表示しましょう %>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-          </div>
-          <div class='item-info'>          
+            </div>
+            <div class='item-info'>          
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>  
+        </li>
+      <% end %> 
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.blank? %> 
+        <li class='list'> 
+          <%= link_to '#' do  %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> 
+          <div class='item-info'>
             <h3 class='item-name'>
-              <%= item.name %>
+              商品を出品してね！
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
+              <span>99999999円<br>(税込み)</span>
               <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
+                <%= image_tag "star.png", class:"star-icon" %> 
                 <span class='star-count'>0</span>
               </div>
             </div>
           </div>
-        <% end %>  
-      </li>
-    <% end %> 
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <% end %> 
+        </li>
+      <% end %> 
+      <%# //商品がある場合は表示されないようにしましょう %>
+      <%# /商品がない場合のダミー %>
+      </div>
     </ul>
-  </div>
   <%# /商品一覧 %>
-</div>
+  </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
   <%= link_to image_tag('camera.png', size: '185x50',class: "purchase-btn-icon"), new_item_path, method: :get %> 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -160,30 +160,7 @@
       <% end %>  
     <% end %> 
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <li class='list'> %>
-
-        <%# <%= link_to '#' do %> 
-        <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %> 
-        <%# <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'> %>
-              <%# <%= image_tag "star.png", class:"star-icon" %> 
-              <%# <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div> %>
-        <%# <% end %> 
-      <%# </li> %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
-    <%# </ul> %>
+    </ul>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, CategoryChoice.all, :id, :choice, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_choice_id, CategoryChoice.all, :id, :choice, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:item_status_id, ItemStatusChoice.all, :id, :choice, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_status_choice_id, ItemStatusChoice.all, :id, :choice, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:send_fee_id, SendFeeChoice.all, :id, :choice, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:send_fee_choice_id, SendFeeChoice.all, :id, :choice, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:send_area_id, SendAreaChoice.all, :id, :choice, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:send_area_choice_id, SendAreaChoice.all, :id, :choice, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:send_date_id, SendDateChoice.all, :id, :choice, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:send_date_choice_id, SendDateChoice.all, :id, :choice, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -49,7 +49,6 @@
         <tr>
           <th class="detail-item">カテゴリー</th>
           <td class="detail-value">
-            <%# <%= CategoryChoice.data[(@item.category_id - 1)][:choice]  %>
             <%= @item.category_choice.choice %>
  
           </td> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,22 +1,21 @@
 <%= render "shared/header" %>
-
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,47 +23,51 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value">
+            <%= CategoryChoice.data[(@item.category_id - 1)][:choice]  %> 
+          </td> 
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= ItemStatusChoice.data[(@item.item_status_id - 1)][:choice] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= SendFeeChoice.data[(@item.send_fee_id - 1)][:choice] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= SendAreaChoice.data[(@item.send_area_id - 1)][:choice] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
+          <td class="detail-value"><%= SendDateChoice.data[(@item.send_date_id - 1)][:choice] %></td>
+        </tr>   
       </tbody>
     </table>
     <div class="option">
@@ -104,5 +107,4 @@
   </div>
   <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
 </div>
-
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -107,6 +107,6 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category_choice.choice %>をもっと見る</a>
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -49,8 +49,7 @@
         <tr>
           <th class="detail-item">カテゴリー</th>
           <td class="detail-value">
-            <%= @item.category_choice.choice %>
- 
+            <%= @item.category_choice.choice %> 
           </td> 
         </tr>
         <tr>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -49,24 +49,26 @@
         <tr>
           <th class="detail-item">カテゴリー</th>
           <td class="detail-value">
-            <%= CategoryChoice.data[(@item.category_id - 1)][:choice]  %> 
+            <%# <%= CategoryChoice.data[(@item.category_id - 1)][:choice]  %>
+            <%= @item.category_choice.choice %>
+ 
           </td> 
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= ItemStatusChoice.data[(@item.item_status_id - 1)][:choice] %></td>
+          <td class="detail-value"><%= @item.item_status_choice.choice %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= SendFeeChoice.data[(@item.send_fee_id - 1)][:choice] %></td>
+          <td class="detail-value"><%= @item.send_fee_choice.choice %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= SendAreaChoice.data[(@item.send_area_id - 1)][:choice] %></td>
+          <td class="detail-value"><%= @item.send_area_choice.choice %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= SendDateChoice.data[(@item.send_date_id - 1)][:choice] %></td>
+          <td class="detail-value"><%= @item.send_date_choice.choice %></td>
         </tr>   
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,9 +29,9 @@
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-
+      <% if user_signed_in?  %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <% end %>

--- a/db/migrate/20200925160506_create_items.rb
+++ b/db/migrate/20200925160506_create_items.rb
@@ -5,11 +5,11 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.string :name,            null: false, default:""
       t.text :explanation,       null: false
       t.integer :price,          null: false
-      t.integer :category_id,    null: false
-      t.integer :item_status_id, null: false
-      t.integer :send_area_id,   null: false
-      t.integer :send_date_id,   null: false
-      t.integer :send_fee_id,    null: false
+      t.integer :category_choice_id,    null: false
+      t.integer :item_status_choice_id, null: false
+      t.integer :send_area_choice_id,   null: false
+      t.integer :send_date_choice_id,   null: false
+      t.integer :send_fee_choice_id,    null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,11 +38,11 @@ ActiveRecord::Schema.define(version: 2020_09_26_065302) do
     t.string "name", default: "", null: false
     t.text "explanation", null: false
     t.integer "price", null: false
-    t.integer "category_id", null: false
-    t.integer "item_status_id", null: false
-    t.integer "send_area_id", null: false
-    t.integer "send_date_id", null: false
-    t.integer "send_fee_id", null: false
+    t.integer "category_choice_id", null: false
+    t.integer "item_status_choice_id", null: false
+    t.integer "send_area_choice_id", null: false
+    t.integer "send_date_choice_id", null: false
+    t.integer "send_fee_choice_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
     name { Faker::Lorem.words }
-    item_status_id { Faker::Number.digit }
     explanation { Faker::Lorem.sentence }
     price { Faker::Number.within(range: 300..9999999) }
-    category_id { Faker::Number.digit }
-    send_area_id { Faker::Number.digit }
-    send_date_id { Faker::Number.digit }
-    send_fee_id { Faker::Number.digit }
+    category_choice_id { Faker::Number.within(range: 2..11) }
+    item_status_choice_id { Faker::Number.within(range: 2..6) }
+    send_area_choice_id { Faker::Number.within(range: 2..48) }
+    send_date_choice_id { Faker::Number.within(range: 2..4) }
+    send_fee_choice_id { Faker::Number.within(range: 2..3) }
 
     association :user
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,7 +7,6 @@ describe '商品出品' do
     @item.image = fixture_file_upload("/files/test_image.png")
   end
   it "name, explanation, price, category_choice_id, item_status_choice_id, send_date_choice_id, send_fee_choice_id, imageがあれば出品登録できる" do
-    # binding.pry
     expect(@item).to be_valid
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,7 +6,8 @@ describe '商品出品' do
     @item = FactoryBot.build(:item)
     @item.image = fixture_file_upload("/files/test_image.png")
   end
-  it "name, explanation, price, category_id, item_status_id, send_date_id, send_fee_id, imageがあれば出品登録できる" do
+  it "name, explanation, price, category_choice_id, item_status_choice_id, send_date_choice_id, send_fee_choice_id, imageがあれば出品登録できる" do
+    # binding.pry
     expect(@item).to be_valid
   end
 
@@ -25,30 +26,30 @@ describe '商品出品' do
     @item.valid?
     expect(@item.errors.full_messages).to include("Price can't be blank")
   end
-  it "category_idが空欄の場合登録できないこと" do
-    @item.category_id = nil 
+  it "category_choice_idが空欄の場合登録できないこと" do
+    @item.category_choice_id = nil 
     @item.valid?
-    expect(@item.errors.full_messages).to include("Category can't be blank", "Category  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Category choice can't be blank", "Category choice  Other than '---' select")
   end
-  it "item_status_idが空欄の場合登録できないこと" do
-    @item.item_status_id = nil
+  it "item_status_choice_idが空欄の場合登録できないこと" do
+    @item.item_status_choice_id = nil
     @item.valid?
-    expect(@item.errors.full_messages).to include("Item status can't be blank", "Item status  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Item status choice can't be blank", "Item status choice  Other than '---' select")
   end
-  it "send_area_idが空欄の場合登録できないこと" do
-    @item.send_area_id = nil 
+  it "send_area_choice_idが空欄の場合登録できないこと" do
+    @item.send_area_choice_id = nil 
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send area can't be blank", "Send area  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send area choice can't be blank", "Send area choice  Other than '---' select")
   end
-  it "send_date_idが空欄の場合登録できないこと" do
-    @item.send_date_id = nil
+  it "send_date_choice_idが空欄の場合登録できないこと" do
+    @item.send_date_choice_id = nil
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send date can't be blank", "Send date  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send date choice can't be blank", "Send date choice  Other than '---' select")
   end
-  it "send_fee_idが空欄の場合登録できないこと" do
-    @item.send_fee_id = nil
+  it "send_fee_choice_idが空欄の場合登録できないこと" do
+    @item.send_fee_choice_id = nil
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send fee can't be blank", "Send fee  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send fee choice can't be blank", "Send fee choice  Other than '---' select")
   end
   it "imageが空欄の場合登録できないこと" do
     @item.image = nil
@@ -56,30 +57,30 @@ describe '商品出品' do
     expect(@item.errors.full_messages).to include("Image can't be blank")
   end
 
-  it "category_idが1の場合登録できないこと" do
-    @item.category_id = 1 
+  it "category_choice_idが1の場合登録できないこと" do
+    @item.category_choice_id = 1 
     @item.valid?
-    expect(@item.errors.full_messages).to include("Category  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Category choice  Other than '---' select")
   end
-  it "item_status_idが1の場合登録できないこと" do
-    @item.item_status_id = 1
+  it "item_status_choice_idが1の場合登録できないこと" do
+    @item.item_status_choice_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Item status  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Item status choice  Other than '---' select")
   end
-  it "send_area_idが1の場合登録できないこと" do
-    @item.send_area_id = 1 
+  it "send_area_choice_idが1の場合登録できないこと" do
+    @item.send_area_choice_id = 1 
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send area  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send area choice  Other than '---' select")
   end
-  it "send_date_idが1の場合登録できないこと" do
-    @item.send_date_id = 1
+  it "send_date_choice_idが1の場合登録できないこと" do
+    @item.send_date_choice_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send date  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send date choice  Other than '---' select")
   end
-  it "send_fee_idが1の場合登録できないこと" do
-    @item.send_fee_id = 1
+  it "send_fee_choice_idが1の場合登録できないこと" do
+    @item.send_fee_choice_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Send fee  Other than '---' select")
+    expect(@item.errors.full_messages).to include("Send fee choice  Other than '---' select")
   end
 
   it "priceがの10,000,000円以上の場合では登録できないこと" do


### PR DESCRIPTION
What
商品詳細表示機能の実装
　(1)商品の各種情報の表示
　　（商品名などの基本情報に加え、出品者、カテゴリー、状態、配送に関する詳細内容の表示）

　(2)ログインの有無、ユーザー別の出品商品対する選択表示
　　・出品者本人（ログイン時）：「編集」・「削除」選択を表示
　　・出品者以外のユーザー（ログイン時）:「購入」選択のみ表示
　　・未ログイン時：商品情報の閲覧のみ（全ての選択非表示）

Why
商品の詳細の情報を表示させるページの実装の為

実装時の様子の写真は以下のGyazoのURLを参照願います。
 (1)出品者本人の場合
　　https://gyazo.com/91ebbeb453c49632fd105efd1e139f70
　　https://gyazo.com/a39e7e82bde625620dd72920ac766edb

 (2)出品者以外のユーザーの場合
　　https://gyazo.com/61f62cfed47b50b47c0b35841ded141e
　　https://gyazo.com/0ce9e02d93b7073a2acfb2ef8e688924

 (3)未ログイン時の場合
　　https://gyazo.com/483251a192e89f78d5f0ea8fe45ddf74
　　https://gyazo.com/f60c22698696167705c480df60ecb97b