### PR TITLE
商品情報編集機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-    before_action :set_item, only: [:show]
+    before_action :set_item, only: [:show, :edit]
     before_action :move_to_sign_in, except: [:index, :show, :search]
 
     def index
@@ -14,6 +14,15 @@ class ItemsController < ApplicationController
     end
 
     def edit
+    end
+
+    def update
+        @item = Item.update(item_params)
+        if @item
+            redirect_to root_path
+        else
+            render :edit
+        end
     end
 
     def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
     before_action :set_item, only: [:show, :edit]
     before_action :move_to_sign_in, except: [:index, :show, :search]
+    before_action :edit_protect, only: [:edit]
 
     def index
         @items = Item.includes(:user).order("created_at DESC")
@@ -14,11 +15,11 @@ class ItemsController < ApplicationController
     end
 
     def edit
-        edit_protect
     end
 
     def update
-        @item = Item.update(item_params)
+        item = Item.find(params[:id])
+        @item = item.update(item_params)
         if @item
             redirect_to root_path
         else
@@ -53,7 +54,6 @@ class ItemsController < ApplicationController
     end
 
     def edit_protect
-        @item = Item.find(params[:id])
         unless current_user.id == @item.user.id
             redirect_to root_path
         end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,6 +14,7 @@ class ItemsController < ApplicationController
     end
 
     def edit
+        edit_protect
     end
 
     def update
@@ -50,4 +51,12 @@ class ItemsController < ApplicationController
     def set_item
         @item = Item.find(params[:id])
     end
+
+    def edit_protect
+        @item = Item.find(params[:id])
+        unless current_user.id == @item.user.id
+            redirect_to root_path
+        end
+    end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,14 +5,15 @@ class ItemsController < ApplicationController
     def index
         @items = Item.includes(:user).order("created_at DESC")
     end
-
     
     def new
         @item = Item.new
     end
     
-    def show
-        @items = Item.order("created_at DESC")
+    def show    
+    end
+
+    def edit
     end
 
     def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-    before_action :set_item, only: [:show, :edit]
+    before_action :set_item, only: [:show, :edit, :update]
     before_action :move_to_sign_in, except: [:index, :show, :search]
     before_action :edit_protect, only: [:edit]
 
@@ -17,10 +17,8 @@ class ItemsController < ApplicationController
     def edit
     end
 
-    def update
-        item = Item.find(params[:id])
-        @item = item.update(item_params)
-        if @item
+    def update      
+        if @item.update(item_params)
             redirect_to root_path
         else
             render :edit

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,6 +22,7 @@ app/assets/stylesheets/items/new.css %>
       <div class="click-upload">
         <p>
           クリックしてファイルをアップロード
+          (写真を選択しない場合は元の写真となります)
         </p>
         <%= f.file_field :image, id:"item-image" ,value:"f.image"%>
       </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item), method: :patch, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" ,value:"f.image"%>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_choice_id, CategoryChoice.all, :id, :choice, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_status_choice_id, ItemStatusChoice.all, :id, :choice, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:send_fee_choice_id, SendFeeChoice.all, :id, :choice, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:send_area_choice_id, SendAreaChoice.all, :id, :choice, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:send_date_choice_id, SendDateChoice.all, :id, :choice, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% else %>


### PR DESCRIPTION
What
出品商品情報編集機能実装
　・商品情報の編集ページの遷移後、元の情報が表示されている（商品写真は除く）
　・写真のファイルは添付選択しない場合は、元のファイルが表示される
　・出品した本人以外が直接編集ページに遷移しようとするとroot_pathに遷移する

Why
出品商品の情報の編集機能を実装する為

実装の様子は以下のGyazoのURLを参照願います。

 （１）編集ページの様子
　　https://gyazo.com/610ed35ee82928279277aca5ec63f726
　　https://gyazo.com/4d1ca5b29b5f788e0c96d7b86387857a
　　https://gyazo.com/77fac801b54388611332acea1cc55ec6
　　https://gyazo.com/866e144bc382a7b599b7d6d5a15d6710

 （２）出品者以外が直接編集ページに遷移した場合
　　https://gyazo.com/f030a57385ab7fccf07795418f6fbcf8
　　https://gyazo.com/be493e0078b05dfd0a7b604377e7ac35
　　https://gyazo.com/4fef0a090971cc728bd92594d7a765f4